### PR TITLE
Change code layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 This package provides the essential building blocks for constitutive hyperelastic material formulations. This includes material behaviour-independent spaces and frameworks as well as material behaviour-dependent model formulations.
 
-**Spaces** are full or partial deformations on which a given material formulation should be projected to, e.g. to the distortional (part of the deformation) space. Generalized *Total-Lagrange* **Frameworks** for isotropic hyperelastic material formulations based on the invariants of the right Cauchy-Green deformation tensor and the principal stretches enable a clean coding of isotropic material formulations.
+**Spaces** ([`hyperelastic.spaces`](https://github.com/adtzlr/hyperelastic/tree/main/src/hyperelastic/spaces)) are full or partial deformations on which a given material formulation should be projected to, e.g. to the distortional (part of the deformation) space. Generalized *Total-Lagrange* **Frameworks** ([`hyperelastic.frameworks`](https://github.com/adtzlr/hyperelastic/tree/main/src/hyperelastic/frameworks)) for isotropic hyperelastic material formulations based on the invariants of the right Cauchy-Green deformation tensor and the principal stretches enable a clean coding of isotropic material formulations.
 
-The math-module provides helpers in reduced vector ([Voigt](https://en.wikipedia.org/wiki/Voigt_notation)) storage for symmetric three-dimensional second-order tensors along with a matrix storage for (at least minor) symmetric three-dimensional fourth-order tensors. Shear terms are not doubled for strain-like tensors, instead all math operations take care of the reduced vector storage.
+The [`hyperelastic.math`](https://github.com/adtzlr/hyperelastic/tree/main/src/hyperelastic/math)-module provides helpers in reduced vector ([Voigt](https://en.wikipedia.org/wiki/Voigt_notation)) storage for symmetric three-dimensional second-order tensors along with a matrix storage for (at least minor) symmetric three-dimensional fourth-order tensors. Shear terms are not doubled for strain-like tensors, instead all math operations take care of the reduced vector storage.
 
 $$ \boldsymbol{C} = \begin{bmatrix} C_{11} & C_{22} & C_{33} & C_{12} & C_{23} & C_{13} \end{bmatrix}^T $$
 
@@ -69,8 +69,8 @@ class MyInvariantsModel:
 
 
 model = MyInvariantsModel()
-framework = hel.frameworks.InvariantsFramework(model)
-umat = hel.spaces.DistortionalSpace(framework)
+framework = hel.InvariantsFramework(model)
+umat = hel.DistortionalSpace(framework)
 ```
 
 ### Available isotropic hyperelastic invariant-based material formulations
@@ -109,8 +109,8 @@ class MyStretchesModel:
 
 
 model = MyStretchesModel()
-framework = hel.frameworks.StretchesFramework(model)
-umat = hel.spaces.DistortionalSpace(framework)
+framework = hel.StretchesFramework(model)
+umat = hel.DistortionalSpace(framework)
 ```
 
 ### Available isotropic hyperelastic stretch-based material formulations
@@ -121,8 +121,8 @@ By using [matadi](https://github.com/adtzlr/matadi)'s `LabIncompressible`, numer
 
 ```python
 mooney_rivlin = hel.models.invariants.ThirdOrderDeformation(C10=0.3, C01=0.2)
-framework = hel.frameworks.InvariantsFramework(mooney_rivlin)
-umat = hel.spaces.DistortionalSpace(framework)
+framework = hel.InvariantsFramework(mooney_rivlin)
+umat = hel.DistortionalSpace(framework)
 
 import matadi
 

--- a/src/hyperelastic/__init__.py
+++ b/src/hyperelastic/__init__.py
@@ -1,4 +1,20 @@
 from . import frameworks, math, models, spaces
 from .__about__ import __version__
+from .frameworks import Invariants as InvariantsFramework
+from .frameworks import Stretches as StretchesFramework
+from .spaces import Deformation as DeformationSpace
+from .spaces import Dilatational as DilatationalSpace
+from .spaces import Distortional as DistortionalSpace
 
-__all__ = ["spaces", "frameworks", "math", "models", "__version__"]
+__all__ = [
+    "spaces",
+    "frameworks",
+    "math",
+    "models",
+    "__version__",
+    "DistortionalSpace",
+    "DilatationalSpace",
+    "DeformationSpace",
+    "InvariantsFramework",
+    "StretchesFramework",
+]

--- a/src/hyperelastic/frameworks/__init__.py
+++ b/src/hyperelastic/frameworks/__init__.py
@@ -1,4 +1,4 @@
-from ._invariants import InvariantsFramework
-from ._stretches import StretchesFramework
+from ._invariants import Invariants
+from ._stretches import Stretches
 
-__all__ = ["InvariantsFramework", "StretchesFramework"]
+__all__ = ["Invariants", "Stretches"]

--- a/src/hyperelastic/frameworks/_invariants.py
+++ b/src/hyperelastic/frameworks/_invariants.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..math import cdya, ddot, det, dya, eye, inv, trace
 
 
-class InvariantsFramework:
+class Invariants:
     r"""The Framework for a Total-Lagrangian invariant-based isotropic hyperelastic
     material formulation provides the material behaviour-independent parts for
     evaluating the second Piola-Kirchhoff stress tensor as well as its associated

--- a/src/hyperelastic/frameworks/_stretches.py
+++ b/src/hyperelastic/frameworks/_stretches.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..math import cdya, dya, eigh, transpose
 
 
-class StretchesFramework:
+class Stretches:
     r"""The Framework for a Total-Lagrangian stretch-based isotropic hyperelastic
     material formulation provides the material behaviour-independent parts for
     evaluating the second Piola-Kirchhoff stress tensor as well as its associated

--- a/src/hyperelastic/spaces/__init__.py
+++ b/src/hyperelastic/spaces/__init__.py
@@ -1,5 +1,5 @@
-from ._deformation import DeformationSpace
-from ._dilatational import DilatationalSpace
-from ._distortional import DistortionalSpace
+from ._deformation import Deformation
+from ._dilatational import Dilatational
+from ._distortional import Distortional
 
-__all__ = ["DistortionalSpace", "DilatationalSpace", "DeformationSpace"]
+__all__ = ["Distortional", "Dilatational", "Deformation"]

--- a/src/hyperelastic/spaces/_deformation.py
+++ b/src/hyperelastic/spaces/_deformation.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..math import astensor, asvoigt, cdya_ik, eye
 
 
-class DeformationSpace:
+class Deformation:
     r"""The deformation space.
 
     This class takes a Total-Lagrange material formulation and applies it on the

--- a/src/hyperelastic/spaces/_dilatational.py
+++ b/src/hyperelastic/spaces/_dilatational.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..math import astensor, asvoigt, cdya, cdya_ik, ddot, det, dya, eye, inv, trace
 
 
-class DilatationalSpace:
+class Dilatational:
     def __init__(self, material, parallel=False):
         self.parallel = parallel
         self.material = material

--- a/src/hyperelastic/spaces/_distortional.py
+++ b/src/hyperelastic/spaces/_distortional.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..math import astensor, asvoigt, cdya, cdya_ik, ddot, det, dya, eye, inv, transpose
 
 
-class DistortionalSpace:
+class Distortional:
     r"""The distortional (part of the deformation) space is a partial deformation with
     constant volume. For a given deformation map :math:`x(X)` and its deformation
     gradient :math:`\boldsymbol{F}`, the distortional part of the deformation gradient

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -20,7 +20,7 @@ def fea(umat):
 
 def test_distortional_stretches():
     model = hel.models.stretches.Ogden(mu=[1], alpha=[0.436])
-    umat = hel.spaces.DistortionalSpace(hel.frameworks.StretchesFramework(model))
+    umat = hel.DistortionalSpace(hel.StretchesFramework(model))
     fea(umat).evaluate(verbose=2)
 
 
@@ -28,13 +28,13 @@ def test_distortional_invariants():
     model = hel.models.invariants.ThirdOrderDeformation(
         C10=0.4, C01=0.1, C11=0.02, C20=-0.05, C30=0.01
     )
-    umat = hel.spaces.DistortionalSpace(hel.frameworks.InvariantsFramework(model))
+    umat = hel.DistortionalSpace(hel.InvariantsFramework(model))
     fea(umat).evaluate(verbose=2)
 
 
 def test_dilatational_invariants():
     model = hel.models.invariants.ThirdOrderDeformation(C10=0.5)
-    umat = hel.spaces.DilatationalSpace(hel.frameworks.InvariantsFramework(model))
+    umat = hel.DilatationalSpace(hel.InvariantsFramework(model))
     fea(umat).evaluate(verbose=2)
 
 
@@ -42,7 +42,7 @@ def test_deformation_invariants():
     model = hel.models.invariants.ThirdOrderDeformation(
         C10=0.4, C01=0.1, C11=0.02, C20=-0.05, C30=0.01
     )
-    umat = hel.spaces.DeformationSpace(hel.frameworks.InvariantsFramework(model))
+    umat = hel.DeformationSpace(hel.InvariantsFramework(model))
     fea(umat).evaluate(verbose=2)
 
 

--- a/tests/test_sympy.py
+++ b/tests/test_sympy.py
@@ -44,9 +44,15 @@ class SymbolicMaterialFormulation:
             [self.x, self.y, self.z], self.W.diff(self.z, self.z)
         )
 
-        self.d2Wdxdy = lambda x, y, z: np.zeros_like(x)
-        self.d2Wdydz = lambda x, y, z: np.zeros_like(x)
-        self.d2Wdxdz = lambda x, y, z: np.zeros_like(x)
+        self.d2Wdxdy = sym.lambdify(
+            [self.x, self.y, self.z], self.W.diff(self.x, self.y)
+        )
+        self.d2Wdydz = sym.lambdify(
+            [self.x, self.y, self.z], self.W.diff(self.y, self.z)
+        )
+        self.d2Wdxdz = sym.lambdify(
+            [self.x, self.y, self.z], self.W.diff(self.x, self.z)
+        )
 
     def gradient(self, stretches, statevars):
         return [
@@ -56,21 +62,19 @@ class SymbolicMaterialFormulation:
         ], statevars
 
     def hessian(self, stretches, statevars):
-        return np.array(
-            [
-                self.d2Wdxdx(*stretches),
-                self.d2Wdydy(*stretches),
-                self.d2Wdzdz(*stretches),
-                self.d2Wdxdy(*stretches),
-                self.d2Wdydz(*stretches),
-                self.d2Wdxdz(*stretches),
-            ]
-        )
+        return [
+            self.d2Wdxdx(*stretches),
+            self.d2Wdydy(*stretches),
+            self.d2Wdzdz(*stretches),
+            self.d2Wdxdy(*stretches),
+            self.d2Wdydz(*stretches),
+            self.d2Wdxdz(*stretches),
+        ]
 
 
 def test_distortional_stretches_sympy():
     model = SymbolicMaterialFormulation(ogden, mu=1, alpha=0.436)
-    umat = hel.spaces.DistortionalSpace(hel.frameworks.StretchesFramework(model))
+    umat = hel.DistortionalSpace(hel.StretchesFramework(model))
     fea(umat).evaluate(verbose=2)
 
 


### PR DESCRIPTION
Use short class names in submodules like `hyperelastic.spaces.Distortional()` or `hyperelastic.frameworks.Stretches()` and import them to the global package namespace as well: `hyperelastic.DistortionalSpace()`, `hyperelastic.StretchesFramework()`, etc.